### PR TITLE
fix(type-check-errors): update type definitions & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 /.pnp
+/playwright-report
+/test-results
+
 .pnp.*
 .yarn/*
 !.yarn/patches

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@types/jest": "^30.0.0",
         "@types/luxon": "^3.7.1",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2083,9 +2084,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3725,6 +3726,52 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
@@ -7092,9 +7139,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9151,9 +9198,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@types/jest": "^30.0.0",
     "@types/luxon": "^3.7.1",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/lib/auth/__tests__/options.test.ts
+++ b/src/lib/auth/__tests__/options.test.ts
@@ -1,4 +1,5 @@
 import { authOptions } from '../options';
+import type { AdapterUser, Session } from 'next-auth';
 
 describe('Authentication Options', () => {
   describe('Provider Configuration', () => {
@@ -52,13 +53,13 @@ describe('Authentication Options', () => {
   describe('Debug Mode', () => {
     it('should enable debug in development', () => {
       const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'development';
+      (process.env as { NODE_ENV?: string }).NODE_ENV = 'development';
 
       // Note: authOptions is already imported with current NODE_ENV
       // In real scenario, we'd need to dynamically import
       expect(authOptions.debug).toBeDefined();
 
-      process.env.NODE_ENV = originalEnv;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = originalEnv;
     });
   });
 });
@@ -115,8 +116,16 @@ describe('JWT Callback', () => {
       },
     };
 
+    const mockUser = {
+      id: 'user123',
+      name: 'Test User',
+      email: 'test@example.com',
+    };
+
     const result = await mockJWT({
       token: existingToken,
+      user: mockUser,
+      account: null,
       trigger: 'update',
     });
 
@@ -156,11 +165,13 @@ describe('Session Callback', () => {
     const result = await mockSession({
       session: mockSessionInput,
       token: mockToken,
-      trigger: 'getSession',
+      user: mockToken.user as AdapterUser,
+      newSession: mockSessionInput,
+      trigger: 'update',
     });
 
     expect(result.user).toEqual(mockToken.user);
-    expect(result.accessToken).toBe('mock_access_token');
+    expect((result as Session).accessToken).toBe('mock_access_token');
   });
 
   it('should include error in session if present', async () => {
@@ -190,9 +201,11 @@ describe('Session Callback', () => {
     const result = await mockSession({
       session: mockSessionInput,
       token: mockToken,
-      trigger: 'getSession',
+      user: mockToken.user as AdapterUser,
+      newSession: mockSessionInput,
+      trigger: 'update',
     });
 
-    expect(result.error).toBe('RefreshAccessTokenError');
+    expect((result as Session).error).toBe('RefreshAccessTokenError');
   });
 });


### PR DESCRIPTION


- Add @types/jest for improved type checking in tests
- Update js-yaml and glob to latest versions to resolve vulnerabilities
- Update .gitignore to exclude Playwright test artifacts
- Resolve type errors in authentication options tests
- Update package-lock.json to include @types/jest and update dependencies