### PR TITLE
feat(compensation): compensation display and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material": "^7.3.5",
         "@pagerduty/pdjs": "^2.2.4",
         "axios": "^1.13.2",
-        "caloohpay": "^2.0.0",
+        "caloohpay": "^2.1.0",
         "date-fns": "^4.1.0",
         "luxon": "^3.7.2",
         "next": "16.0.1",
@@ -5114,9 +5114,9 @@
       }
     },
     "node_modules/caloohpay": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caloohpay/-/caloohpay-2.0.0.tgz",
-      "integrity": "sha512-7US1NoBj4HWDIrP1kmd+r30Mdm6O/RnK6HYwIJiStcvZHRzfmsxaJAF1t5pmAsqyZqKtd3XhmCBQ7HjnQbvZyw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/caloohpay/-/caloohpay-2.1.0.tgz",
+      "integrity": "sha512-dZDxt+2ikaq9JuSOXJKl9M1Cn4zJ5OJmELsiCd+qM8Bm3/tQEjtKfY0yGcfkIWOuE/3aI81guz8gEksef+CNVg==",
       "license": "ISC",
       "dependencies": {
         "@pagerduty/pdjs": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@mui/material": "^7.3.5",
     "@pagerduty/pdjs": "^2.2.4",
     "axios": "^1.13.2",
-    "caloohpay": "^2.0.0",
+    "caloohpay": "^2.1.0",
     "date-fns": "^4.1.0",
     "luxon": "^3.7.2",
     "next": "16.0.1",

--- a/src/lib/caloohpay.ts
+++ b/src/lib/caloohpay.ts
@@ -2,7 +2,9 @@
  * Re-exports from the official caloohpay npm package
  * https://www.npmjs.com/package/caloohpay
  * https://github.com/lonelydev/caloohpay
+ *
+ * Using caloohpay/core for browser-compatible exports only
  */
 
-export { OnCallPeriod, OnCallUser, OnCallPaymentsCalculator } from 'caloohpay';
-export type { OnCallCompensation } from 'caloohpay';
+export { OnCallPeriod, OnCallUser, OnCallPaymentsCalculator } from 'caloohpay/core';
+export type { OnCallCompensation } from 'caloohpay/core';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -4,8 +4,8 @@
  */
 
 // Re-export types from the official caloohpay package
-export type { OnCallPeriod, OnCallUser } from 'caloohpay';
-import type { OnCallCompensation as CaloohpayCompensation } from 'caloohpay';
+export type { OnCallPeriod, OnCallUser } from 'caloohpay/core';
+import type { OnCallCompensation as CaloohpayCompensation } from 'caloohpay/core';
 
 /**
  * PagerDuty User information

--- a/src/lib/utils/csvExport.ts
+++ b/src/lib/utils/csvExport.ts
@@ -2,7 +2,7 @@
  * CSV export utilities for payment data
  */
 
-import type { OnCallCompensation } from 'caloohpay';
+import type { OnCallCompensation } from 'caloohpay/core';
 import type { CSVExportData } from '@/lib/types';
 import { PAYMENT_RATES } from '@/lib/constants';
 

--- a/src/lib/utils/scheduleUtils.ts
+++ b/src/lib/utils/scheduleUtils.ts
@@ -2,7 +2,7 @@
  * Utilities for processing PagerDuty schedule data
  */
 
-import { OnCallPeriod, OnCallUser } from 'caloohpay';
+import { OnCallPeriod, OnCallUser } from 'caloohpay/core';
 import type { PagerDutySchedule, ScheduleEntry } from '@/lib/types';
 
 /**


### PR DESCRIPTION
- Display compensation breakdown per shift entry (weekdays × £50 + weekends × £75)
- Show total compensation, weekdays, and weekends for each user
- All compensation follows caloohpay default rates
- Update package to caloohpay@2.1.0 with /core exports
- Use centralized PAYMENT_RATES constants
- Replace all imports from 'caloohpay' with 'caloohpay/core' to use browser-compatible exports that exclude Node.js dependencies like 'fs'.
  - This resolves 'Module not found: Can't resolve fs' build errors when running the application in the browser, as the main caloohpay export includes Node.js-specific modules (CsvWriter, ConfigLoader) that cannot be bundled for the client.
- Additionally, remove duplicate OnCallPeriod class implementation (130+ lines) from schedule detail page in favour of the official package export, reducing code duplication and maintenance burden.
- Fix SWR fetcher to support both OAuth and API token authentication methods when fetching data from PagerDuty API.